### PR TITLE
Refactor resource loading

### DIFF
--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -1494,7 +1494,7 @@ void TextureGroups_constructTreeView( TextureGroups& groups ){
 	{
 		// scan texture dirs and pak files only if not restricting to shaderlist
 		if ( g_pGameDescription->mGameType != "doom3" && !g_TextureBrowser_shaderlistOnly ) {
-			GlobalFileSystem().forEachDirectory( "textures/", TextureGroupsAddDirectoryCaller( groups ) );
+			GlobalFileSystem().forEachDirectory( "textures/", TextureGroupsAddDirectoryCaller( groups ), TEX_MAX_FOLDER_DEPH );
 		}
 
 		GlobalShaderSystem().foreachShaderName( TextureGroupsAddShaderCaller( groups ) );

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -1494,7 +1494,7 @@ void TextureGroups_constructTreeView( TextureGroups& groups ){
 	{
 		// scan texture dirs and pak files only if not restricting to shaderlist
 		if ( g_pGameDescription->mGameType != "doom3" && !g_TextureBrowser_shaderlistOnly ) {
-			GlobalFileSystem().forEachDirectory( "textures/", TextureGroupsAddDirectoryCaller( groups ), TEX_MAX_FOLDER_DEPH );
+			GlobalFileSystem().forEachDirectory( "textures/", TextureGroupsAddDirectoryCaller( groups ), TEX_MAX_FOLDER_DEPTH );
 		}
 
 		GlobalShaderSystem().foreachShaderName( TextureGroupsAddShaderCaller( groups ) );

--- a/radiant/texwindow.h
+++ b/radiant/texwindow.h
@@ -24,7 +24,7 @@
 #include "generic/callbackfwd.h"
 #include "signal/signalfwd.h"
 
-#define TEX_MAX_FOLDER_DEPH 16
+#define TEX_MAX_FOLDER_DEPTH 16
 
 typedef struct _GtkWidget GtkWidget;
 

--- a/radiant/texwindow.h
+++ b/radiant/texwindow.h
@@ -24,6 +24,8 @@
 #include "generic/callbackfwd.h"
 #include "signal/signalfwd.h"
 
+#define TEX_MAX_FOLDER_DEPH 16
+
 typedef struct _GtkWidget GtkWidget;
 
 class TextureBrowser;


### PR DESCRIPTION
Before this PR if you wanted to have a texture at `world/plastic` you'd have to create a folder named `world_plastic`.
This PR refactors this so you can have nested folders.

Texture browser:
- [x] Increase folder depth
- [ ] Refactor gtk tree code
- [ ] Clean up compiler
     - Compiler has code to correct the path ( ie from `wolrd_plastic` to `world/plastic` ) which wont be needed anymore
- [ ] Test

Model browser:
- [ ] Increase folder depth
- [ ] Refactor gtk tree code
    - Currently `models/` is the root folder which imo doesnt need to be displayed ( texture browser also doesnt show `textures/` )
- [ ] Test