### PR TITLE
Upping spawnflags limit to 32 bits (#43)

### DIFF
--- a/include/ieclass.h
+++ b/include/ieclass.h
@@ -27,7 +27,7 @@
 
 #include "generic/constant.h"
 
-#define MAX_FLAGS   16
+#define MAX_FLAGS   32
 
 // eclass show flags
 


### PR DESCRIPTION
1 line fix for #43
Might look at adding the latest version of [MRVN-Entities](https://github.com/MRVN-Radiant/MRVN-Entities) to `games/` after this

With this fix all [MRVN-Entities](https://github.com/MRVN-Radiant/MRVN-Entities) entities load w/ no explicit errors or warnings