### PR TITLE
Adding BrushSideTextureVectors

### DIFF
--- a/tools/remap/source/lump_names.h
+++ b/tools/remap/source/lump_names.h
@@ -43,7 +43,7 @@
 #define R1_LUMP_CM_BRUSHES                      0x5C
 #define R1_LUMP_CM_BRUSH_SIDE_PLANE_OFFSETS     0x5D
 #define R1_LUMP_CM_BRUSH_SIDE_PROPS             0x5E
-#define R1_LUMP_CM_BRUSH_TEX_VECS               0x5F
+#define R1_LUMP_CM_BRUSH_SIDE_TEX_VECS          0x5F
 #define R1_LUMP_TRICOLL_BEVEL_STARTS            0x60
 #define R1_LUMP_TRICOLL_BEVEL_INDICES           0x61
 #define R1_LUMP_LIGHTMAP_DATA_SKY               0x62
@@ -125,7 +125,7 @@
 #define R2_LUMP_CM_BRUSHES                      0x5C
 #define R2_LUMP_CM_BRUSH_SIDE_PLANES            0x5D
 #define R2_LUMP_CM_BRUSH_SIDE_PROPS             0x5E
-#define R2_LUMP_CM_BRUSH_TEX_VECS               0x5F
+#define R2_LUMP_CM_BRUSH_SIDE_TEX_VECS          0x5F
 #define R2_LUMP_TRICOLL_BEVEL_STARTS            0x60
 #define R2_LUMP_TRICOLL_BEVEL_INDICES           0x61
 #define R2_LUMP_LIGHTMAP_DATA_SKY               0x62

--- a/tools/remap/source/titanfall/titanfall.cpp
+++ b/tools/remap/source/titanfall/titanfall.cpp
@@ -132,6 +132,7 @@ void WriteR1BSPFile(const char *filename) {
     AddLump(file, header.lumps[R1_LUMP_CM_BRUSHES],                  Titanfall::Bsp::cmBrushes);
     AddLump(file, header.lumps[R1_LUMP_CM_BRUSH_SIDE_PROPS],         Titanfall::Bsp::cmBrushSideProperties);
     AddLump(file, header.lumps[R1_LUMP_CM_BRUSH_SIDE_PLANE_OFFSETS], Titanfall::Bsp::cmBrushSidePlaneOffsets);
+    AddLump(file, header.lumps[R1_LUMP_CM_BRUSH_SIDE_TEX_VECS],      Titanfall::Bsp::cmBrushSideTexVecs);
     AddLump(file, header.lumps[R1_LUMP_LIGHTMAP_DATA_SKY],           Titanfall::Bsp::lightMapDataSky_stub);  // stub
     AddLump(file, header.lumps[R1_LUMP_CSM_AABB_NODES],              Titanfall::Bsp::csmAABBNodes_stub);  // stub
     AddLump(file, header.lumps[R1_LUMP_CELL_BSP_NODES],              Titanfall::Bsp::cellBSPNodes_stub);  // stub

--- a/tools/remap/source/titanfall/titanfall.h
+++ b/tools/remap/source/titanfall/titanfall.h
@@ -313,6 +313,14 @@ namespace Titanfall {
         uint32_t  sidePlaneIndex;
     };
 
+    // 0x5F
+    struct CMBrushSideTexVec_t {
+        Vector3  s_axis;
+        float    s_offset;
+        Vector3  t_axis;
+        float    t_offset;
+    };
+
     // 0x77
     struct CellAABBNode_t {
         Vector3   mins;
@@ -388,6 +396,7 @@ namespace Titanfall {
         inline std::vector<int32_t>               cmUniqueContents;
         inline std::vector<CMBrush_t>             cmBrushes;
         inline std::vector<uint16_t>              cmBrushSidePlaneOffsets;
+        inline std::vector<CMBrushSideTexVec_t>   cmBrushSideTexVecs;
         inline std::vector<Vector3>               occlusionMeshVertices;
         inline std::vector<uint16_t>              occlusionMeshIndices;
         inline std::vector<CellAABBNode_t>        cellAABBNodes;

--- a/tools/remap/source/titanfall/titanfall_collisions.cpp
+++ b/tools/remap/source/titanfall/titanfall_collisions.cpp
@@ -222,7 +222,7 @@ void Titanfall::EmitBrush(brush_t &brush) {
     for( side_t &side : brush.sides ) {
         if( !side.bevel )
             brush.contentFlags |= side.shaderInfo->contentFlags;
-            // TODO: 
+            // TODO: collect shader contentClearFlags & mask at the end
     }
 
 

--- a/tools/remap/source/titanfall/titanfall_collisions.cpp
+++ b/tools/remap/source/titanfall/titanfall_collisions.cpp
@@ -222,6 +222,7 @@ void Titanfall::EmitBrush(brush_t &brush) {
     for( side_t &side : brush.sides ) {
         if( !side.bevel )
             brush.contentFlags |= side.shaderInfo->contentFlags;
+            // TODO: 
     }
 
 
@@ -235,18 +236,12 @@ void Titanfall::EmitBrush(brush_t &brush) {
 
     std::vector<side_t>  axialSides;
     std::vector<side_t>  cuttingSides;
-    // +X -X +Y -Y +Z -Z
-    shaderInfo_t *axials[6];
-    // The bsp brushes are AABBs + cutting planes
-    // Surface flags are indexed first for AABB ( first 6 planes ) then for the rest
-    // Radiant brushes are made purely of planes so we dont have a guarantee that we'll get the
-    // Axial ones which define the AABB, that's why we first sort them
     for (const side_t &side : brush.sides) {
         Vector3 normal = side.plane.normal();
         SnapNormal(normal);
         if ((normal[0] == -1.0f || normal[0] == 1.0f || (normal[0] == 0.0f && normal[1] == 0.0f)
-            || normal[1] == -1.0f || normal[1] == 1.0f || (normal[1] == 0.0f && normal[2] == 0.0f)
-            || normal[2] == -1.0f || normal[2] == 1.0f || (normal[2] == 0.0f && normal[0] == 0.0f)) && !side.bevel) {
+          || normal[1] == -1.0f || normal[1] == 1.0f || (normal[1] == 0.0f && normal[2] == 0.0f)
+          || normal[2] == -1.0f || normal[2] == 1.0f || (normal[2] == 0.0f && normal[0] == 0.0f)) && !side.bevel) {
             // Axial
             axialSides.emplace_back(side);
         }
@@ -254,38 +249,59 @@ void Titanfall::EmitBrush(brush_t &brush) {
         cuttingSides.emplace_back(side);
     }
 
+    // +X -X +Y -Y +Z -Z
+    side_t sortedAxialSides[6];
+    sortedAxialSides[0] = {.plane=Plane3(+1, 0, 0, 0)};
+    sortedAxialSides[1] = {.plane=Plane3(-1, 0, 0, 0)};
+    sortedAxialSides[2] = {.plane=Plane3(0, +1, 0, 0)};
+    sortedAxialSides[3] = {.plane=Plane3(0, -1, 0, 0)};
+    sortedAxialSides[4] = {.plane=Plane3(0, 0, +1, 0)};
+    sortedAxialSides[5] = {.plane=Plane3(0, 0, -1, 0)};
+    // The bsp brushes are AABBs + cutting planes
+    // Surface flags are indexed first for AABB ( first 6 planes ) then for the rest
+    // Radiant brushes are made purely of planes so we dont have a guarantee that we'll get the
+    // Axial ones which define the AABB, that's why we first sort them
     for (const side_t &side : axialSides) {
         Vector3 normal = side.plane.normal();
         SnapNormal(normal);
 
         if (normal[0] == 1.0f) {
-            axials[1] = side.shaderInfo;
+            sortedAxialSides[1] = const_cast<side_t&>(side);
         } else if (normal[0] == -1.0f) {
-            axials[0] = side.shaderInfo;
+            sortedAxialSides[0] = const_cast<side_t&>(side);
         }
 
         if (normal[1] == 1.0f) {
-            axials[3] = side.shaderInfo;
+            sortedAxialSides[3] = const_cast<side_t&>(side);
         } else if (normal[1] == -1.0f) {
-            axials[2] = side.shaderInfo;
+            sortedAxialSides[2] = const_cast<side_t&>(side);
         }
 
         if (normal[2] == 1.0f) {
-            axials[5] = side.shaderInfo;
+            sortedAxialSides[5] = const_cast<side_t&>(side);
         } else if (normal[2] == -1.0f) {
-            axials[4] = side.shaderInfo;
+            sortedAxialSides[4] = const_cast<side_t&>(side);
         }
     }
 
     int test = 0;
     for (int i = 0; i < 6; i++) {
-        if (axials[i] != nullptr) {
-            //Titanfall::Bsp::cmBrushSideProperties.emplace_back(Titanfall::EmitTextureData(*axials[i]));
+        side_t side = sortedAxialSides[i];
+        if (side.shaderInfo != nullptr) {
+            // Titanfall::Bsp::cmBrushSideProperties.emplace_back(Titanfall::EmitTextureData(*side.shaderInfo));
             Titanfall::Bsp::cmBrushSideProperties.emplace_back(0);
         } else {
             test++;
             Titanfall::Bsp::cmBrushSideProperties.emplace_back(MASK_DISCARD);
+            // TODO: ensure BrushSideProperty indexes tools/toolsnodraw
+            // -- either always emit nodraw as the first TextureData, or EmitTextureData here & now
         }
+
+        Vector3  s_axis, t_axis;
+        ComputeAxisBase(side.plane.normal(), s_axis, t_axis);
+        auto &tv = Titanfall::Bsp::cmBrushSideTexVecs.emplace_back();
+        tv.s_axis = s_axis;  tv.s_offset = side.texMat[0][2];
+        tv.t_axis = t_axis;  tv.t_offset = side.texMat[1][2];
     }
 
 #if 1
@@ -301,8 +317,15 @@ void Titanfall::EmitBrush(brush_t &brush) {
         Titanfall::EmitPlane(side.plane);
         b.planeCount++;
         Titanfall::Bsp::cmBrushSideProperties.emplace_back(Titanfall::EmitTextureData(*side.shaderInfo));
+
         uint16_t &so = Titanfall::Bsp::cmBrushSidePlaneOffsets.emplace_back();
         so = 0;
+
+        Vector3  s_axis, t_axis;
+        ComputeAxisBase(normal, s_axis, t_axis);
+        auto &tv = Titanfall::Bsp::cmBrushSideTexVecs.emplace_back();
+        tv.s_axis = s_axis;  tv.s_offset = side.texMat[0][2];
+        tv.t_axis = t_axis;  tv.t_offset = side.texMat[1][2];
     }
 
     if (b.planeCount) {

--- a/tools/remap/source/titanfall/titanfall_collisions.cpp
+++ b/tools/remap/source/titanfall/titanfall_collisions.cpp
@@ -63,11 +63,8 @@ void Titanfall::EmitCollisionGrid( entity_t &e ) {
     for( brush_t *brush : gridBrushes )
         Titanfall::EmitBrush( *brush );
 
-
     // Worldspawn size
     Vector3 size = gridSize.maxs - gridSize.mins;
-
-     
 
     // Choose scale
     // The limit seems to be 128x128, try to use size of 256 or higher
@@ -251,12 +248,12 @@ void Titanfall::EmitBrush(brush_t &brush) {
 
     // +X -X +Y -Y +Z -Z
     side_t sortedAxialSides[6];
-    sortedAxialSides[0] = {.plane=Plane3(+1, 0, 0, 0)};
-    sortedAxialSides[1] = {.plane=Plane3(-1, 0, 0, 0)};
-    sortedAxialSides[2] = {.plane=Plane3(0, +1, 0, 0)};
-    sortedAxialSides[3] = {.plane=Plane3(0, -1, 0, 0)};
-    sortedAxialSides[4] = {.plane=Plane3(0, 0, +1, 0)};
-    sortedAxialSides[5] = {.plane=Plane3(0, 0, -1, 0)};
+    sortedAxialSides[0].plane=Plane3(+1, 0, 0, 0);
+    sortedAxialSides[1].plane=Plane3(-1, 0, 0, 0);
+    sortedAxialSides[2].plane=Plane3(0, +1, 0, 0);
+    sortedAxialSides[3].plane=Plane3(0, -1, 0, 0);
+    sortedAxialSides[4].plane=Plane3(0, 0, +1, 0);
+    sortedAxialSides[5].plane=Plane3(0, 0, -1, 0);
     // The bsp brushes are AABBs + cutting planes
     // Surface flags are indexed first for AABB ( first 6 planes ) then for the rest
     // Radiant brushes are made purely of planes so we dont have a guarantee that we'll get the

--- a/tools/remap/source/titanfall2/titanfall2.cpp
+++ b/tools/remap/source/titanfall2/titanfall2.cpp
@@ -143,6 +143,7 @@ void WriteR2BSPFile(const char *filename) {
     AddLump(file, header.lumps[R2_LUMP_CM_BRUSHES],                Titanfall::Bsp::cmBrushes);
     AddLump(file, header.lumps[R2_LUMP_CM_BRUSH_SIDE_PROPS],       Titanfall::Bsp::cmBrushSideProperties);
     AddLump(file, header.lumps[R2_LUMP_CM_BRUSH_SIDE_PLANES],      Titanfall::Bsp::cmBrushSidePlaneOffsets);
+    AddLump(file, header.lumps[R2_LUMP_CM_BRUSH_SIDE_TEX_VECS],    Titanfall::Bsp::cmBrushSideTexVecs);
     // AddLump(file, header.lumps[R2_LUMP_TRICOLL_BEVEL_STARTS],      Titanfall2::bspTricollBevelStarts_stub);  // stub
     AddLump(file, header.lumps[R2_LUMP_LIGHTMAP_DATA_SKY],         Titanfall2::Bsp::lightMapDataSky_stub);  // stub
     AddLump(file, header.lumps[R2_LUMP_CSM_AABB_NODES],            Titanfall::Bsp::csmAABBNodes_stub);  // stub


### PR DESCRIPTION
Kind of a dead end. Failed attempt to fix:
 * #12 

Reverse engineering r2's `engine.dll` shows the lump isn't related
Still want to add the changes though, it could help with decompiles

I've also left in some notes for fixing 2 bugs:
 1) Axial brush sides default to the first material in the map (can lead to mismatched effects & footstep sounds)
 2) Brush contents flags don't take clear flags into account

For a video showing these bugs, see `wet.webm` in:
 * #59 

Bug 1 could be an easy fix
Bug 2 might require a refactor of how we parse brushes into `remap`

Not planning to work on either bug rn, just want to ship this & get back to lightmaps.