### PR TITLE
Allow build action to be triggered manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   Windows:


### PR DESCRIPTION
Since the last commit to main was in November, people can't download the latest builds
It might also be helpful to build older versions remotely when tracking bugs

For right now though, I need to find the source of failing Windows builds in:
 * #72

While it's possible my code is at fault, I want to check if it's due to GitHub's MSVC environment first.
To check that we need to be able to re-run the build action on the latest commit to main.
(I know there's other ways, but imo this is the simplest approach)

In future, we should probably look at making a release so we don't have to re-run actions in development droughts.